### PR TITLE
Amp v2 Compat

### DIFF
--- a/components/validators.js
+++ b/components/validators.js
@@ -1,0 +1,78 @@
+const { flushToMixpanel } = require('./importers.js');
+const dayjs = require('dayjs');
+const utc = require('dayjs/plugin/utc');
+const Job = require('./job');
+dayjs.extend(utc);
+
+
+/**
+ * Validates a mixpanel token; kinda experimental
+ * @param  {string} token
+ * @returns {Promise<{token: string, valid: boolean, type: string}>} details about the token; type is either 'idmgmt_v2', 'idmgmt_v3', or 'unknown'
+ */
+async function validateToken(token) {
+	if (!token) {
+		throw new Error('No Token');
+	}
+	if (typeof token !== 'string') {
+		throw new Error('Token must be a string');
+	}
+	if (token.length !== 32) {
+		throw new Error('Token must be 32 characters');
+	}
+
+	// this event is only valid in v3
+	// ? https://docs.mixpanel.com/docs/tracking-methods/id-management/migrating-to-simplified-id-merge-system#legacy-id-management
+	const veryOldEventBatch = [{
+		event: 'test',
+		properties: {
+			time: dayjs.utc().subtract(4, 'year').valueOf(),
+			$device_id: 'knock',
+			$user_id: 'knock',
+			$insert_id: 'whose',
+			there: "..."
+		}
+	}];
+
+	const result = {
+		token,
+		valid: false,
+		type: ''
+	}
+
+	const config = new Job({ token }, { recordType: 'event', strict: true, verbose: false, logs: false, compress: false, region: 'US' });
+	const res = await flushToMixpanel(veryOldEventBatch, config);
+	
+	//v2_compat requires distinct_id
+	if (res.code === 400) {
+		if (res.failed_records[0].message === `'properties.distinct_id' is invalid: must not be missing`) {
+			result.valid = true;
+			result.type = 'idmgmt_v2';
+		}
+
+		else {
+			result.valid = false;
+			result.type = 'unknown';		
+		}
+	}
+
+	//v3 does not require distinct_id
+	if (res.code === 200) {
+		if (res.num_records_imported === 1) {
+			result.valid = true;
+			result.type = 'idmgmt_v3';
+		}
+
+		else {
+			result.valid = false;
+			result.type = 'unknown';
+		}
+	}
+
+	return result;
+}
+
+
+module.exports = {
+	validateToken
+};

--- a/index.d.ts
+++ b/index.d.ts
@@ -20,6 +20,13 @@ declare namespace main {
     opts: Options,
     finish?: Function
   ): import("stream").Transform;
+  async function validateToken(
+    token: string
+  ): Promise<{
+    token: string;
+    valid: boolean;
+    type: "idmgmt_v2" | "idmgmt_v3" | "unknown";
+  }>;
   /**
    * valid records types which can be imported
    */
@@ -327,10 +334,10 @@ declare namespace main {
      */
     scrubProps?: string[];
 
-	/**
-	 * if true, will add a token or $token to the data
-	 */
-	addToken?: boolean;
+    /**
+     * if true, will add a token or $token to the data
+     */
+    addToken?: boolean;
 
     /**
      * whether or not to write the transformed data to a file instead of sending it to mixpanel
@@ -662,7 +669,7 @@ declare namespace main {
   type amplitudeOpts = {
     user_id?: string;
     group_keys?: string[];
-	v2_compat?: boolean; // use v2 api
+    v2_compat?: boolean; // use v2 api
   };
 
   /**

--- a/index.d.ts
+++ b/index.d.ts
@@ -662,6 +662,7 @@ declare namespace main {
   type amplitudeOpts = {
     user_id?: string;
     group_keys?: string[];
+	v2_compat?: boolean; // use v2 api
   };
 
   /**

--- a/index.js
+++ b/index.js
@@ -32,6 +32,9 @@ const { logger, writeLogs } = require('./components/logs.js');
 // $ utils
 const u = require('ak-tools');
 
+// $ validators
+const { validateToken } = require('./components/validators.js');
+
 const dayjs = require('dayjs');
 const utc = require('dayjs/plugin/utc');
 dayjs.extend(utc);
@@ -111,7 +114,7 @@ async function main(creds = {}, data, opts = {}, isCLI = false) {
 		"rate (per sec)": u.comma(summary.eps)
 	};
 
-	l("STATS");	
+	l("STATS");
 	l(stats, true);
 	l('\n');
 
@@ -171,6 +174,7 @@ EXPORTS
 -------
 */
 
+main.validateToken = validateToken;
 const mpImport = module.exports = main;
 mpImport.createMpStream = pipeInterface;
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "mixpanel-import",
-  "version": "2.5.5",
+  "version": "2.5.51",
   "description": "stream and import data to mixpanel from node.js",
   "main": "index.js",
   "types": "index.d.ts",

--- a/tests/vendor.test.js
+++ b/tests/vendor.test.js
@@ -32,8 +32,11 @@ describe("vendor tests", () => {
 	test(
 		"amplitude: events",
 		async () => {
-			const job = await mp({}, "./testData/amplitude/2023-04-10_1#0.json", { ...opts, recordType: "event", vendor: "amplitude", dryRun: true });
-			expect(job.dryRun.length).toBe(4011);
+			const job = await mp({}, "./testData/amplitude/2023-04-10_1#0.json", { ...opts, recordType: "event", vendor: "amplitude", dryRun: true, vendorOpts: { v2_compat: false }});
+			const numRecords = job.dryRun.length;
+			const numDistinctIds = job.dryRun.filter(a => a.properties.distinct_id).length;
+			expect(numRecords).toBe(4011);
+			expect(numDistinctIds).toBe(0);
 
 		},
 		longTimeout
@@ -44,6 +47,21 @@ describe("vendor tests", () => {
 		async () => {
 			const job = await mp({}, "./testData/amplitude/2023-04-10_1#0.json", { ...opts, recordType: "user", vendor: "amplitude", dryRun: true });
 			expect(job.dryRun.length).toBe(216);
+		},
+		longTimeout
+	);
+
+
+	test(
+		"amplitude: events v2 compat",
+		async () => {
+			const job = await mp({}, "./testData/amplitude/2023-04-10_1#0.json", { ...opts, recordType: "event", vendor: "amplitude", dryRun: true, vendorOpts: { v2_compat: true } });
+			const numRecords = job.dryRun.length;
+			const numDistinctIds = job.dryRun.filter(a => a.properties.distinct_id).length;
+			expect(numRecords).toBe(4011);
+			expect(numDistinctIds).toBe(numRecords);
+			
+
 		},
 		longTimeout
 	);


### PR DESCRIPTION
for amplitude transforms always send distinct_id so events don't fail in v2. 

auto-opt in; disable with  `vendorOpts: { v2_compat: false }`