### PR TITLE
black / whitelist by k:v pairs

### DIFF
--- a/components/cli.js
+++ b/components/cli.js
@@ -359,6 +359,8 @@ function showProgress(record, processed, requests) {
 	const line = `${record}s: ${u.comma(processed)} | batches: ${u.comma(requests)} | memory: ${u.bytesHuman(heapUsed)} (heap: ${u.round(percentHeap)}% total:${u.round(percentRSS)}%)\t\t`;
 	// @ts-ignore
 	readline.cursorTo(process.stdout, 0);
+	// @ts-ignore
+	readline.clearLine(process.stdout, 0);
 	process.stdout.write(line);
 }
 

--- a/components/job.js
+++ b/components/job.js
@@ -203,6 +203,11 @@ class Job {
 			this.whiteAndBlackLister = transforms.whiteAndBlackLister(this, whiteOrBlacklist);
 			this.shouldWhiteBlackList = true;
 		}
+		if (Object.keys(this.comboWhiteList).length > 0 || Object.keys(this.comboBlackList).length > 0) {
+			this.whiteAndBlackLister = transforms.whiteAndBlackLister(this, whiteOrBlacklist);
+			this.shouldWhiteBlackList = true;
+		}
+
 		if (opts.epochStart || opts.epochEnd) {
 			this.shouldEpochFilter = true;
 			this.epochFilter = transforms.epochFilter(this);

--- a/components/job.js
+++ b/components/job.js
@@ -143,6 +143,8 @@ class Job {
 		this.propKeyBlacklist = parse(opts.propKeyBlacklist) || [];
 		this.propValWhitelist = parse(opts.propValWhitelist) || [];
 		this.propValBlacklist = parse(opts.propValBlacklist) || [];
+		this.comboWhiteList = parse(opts.comboWhiteList) || {};
+		this.comboBlackList = parse(opts.comboBlackList) || {};
 		this.scrubProps = parse(opts.scrubProps) || [];
 
 		// @ts-ignore backwards compatibility
@@ -193,7 +195,9 @@ class Job {
 			propKeyWhitelist: this.propKeyWhitelist,
 			propKeyBlacklist: this.propKeyBlacklist,
 			propValWhitelist: this.propValWhitelist,
-			propValBlacklist: this.propValBlacklist
+			propValBlacklist: this.propValBlacklist,
+			comboWhiteList: this.comboWhiteList,
+			comboBlackList: this.comboBlackList
 		};
 		if (Object.values(whiteOrBlacklist).some(array => array.length >= 1)) {
 			this.whiteAndBlackLister = transforms.whiteAndBlackLister(this, whiteOrBlacklist);
@@ -632,6 +636,7 @@ function noop(a) { return a; }
 
 // for catching parse errors
 function returnEmpty(jobConfig) {
+	// eslint-disable-next-line no-unused-vars
 	return function (_err, _record, _reviver) {
 		jobConfig.unparsable++;
 		return {};

--- a/components/pipelines.js
+++ b/components/pipelines.js
@@ -54,8 +54,7 @@ function corePipeline(stream, jobConfig, toNodeStream = false) {
 
 	// @ts-ignore
 	const mpPipeline = _.pipeline(
-
-		//todo: come up with good names for each step?!?!		
+	
 
 		// * only JSON from stream
 		// @ts-ignore

--- a/components/transforms.js
+++ b/components/transforms.js
@@ -481,22 +481,21 @@ function whiteAndBlackLister(jobConfig, params) {
 			if (!pass) return {};
 		}
 
-		//check for combo whitelist
+		//check for combo whitelist		
 		if (Object.keys(comboWhiteList).length) {
-			pass = false;
-			for (const key in comboBlackList) {
-				let propVals = comboBlackList[key];
-				if (!Array.isArray(propVals)) propVals = [propVals];
-				for (const val of propVals) {
-					if (record?.properties?.[key] === val) pass = true;
+			let pass = false; // Assume the record does not pass initially
+			for (const key in comboWhiteList) {
+				let propVals = Array.isArray(comboWhiteList[key]) ? comboWhiteList[key] : [comboWhiteList[key]];
+				if (propVals.includes(record?.properties?.[key])) {
+					pass = true; // If any key-value matches, set pass to true
+					break; // Break early since at least one condition is satisfied
 				}
 			}
-			if (!pass) {
+			if (!pass) { // If after checking all, no match was found
 				jobConfig.whiteListSkipped++;
-				return {};
+				return {}; // Skip the record
 			}
 		}
-
 
 		//check for combo blacklist
 		if (Object.keys(comboBlackList).length) {
@@ -504,8 +503,13 @@ function whiteAndBlackLister(jobConfig, params) {
 			for (const key in comboBlackList) {
 				let propVals = comboBlackList[key];
 				if (!Array.isArray(propVals)) propVals = [propVals];
+				let foundMatch = false;
 				for (const val of propVals) {
-					if (record?.properties?.[key] === val) pass = false;
+					if (record?.properties?.[key] === val) foundMatch = true;
+				}
+				if (foundMatch) {
+					pass = false;
+					break;
 				}
 			}
 			if (!pass) {

--- a/components/transforms.js
+++ b/components/transforms.js
@@ -486,7 +486,7 @@ function whiteAndBlackLister(jobConfig, params) {
 			let pass = false; // Assume the record does not pass initially
 			for (const key in comboWhiteList) {
 				let propVals = Array.isArray(comboWhiteList[key]) ? comboWhiteList[key] : [comboWhiteList[key]];
-				if (propVals.includes(record?.properties?.[key])) {
+				if (propVals.map(v => v?.toString()).includes(record?.properties?.[key]?.toString())) {
 					pass = true; // If any key-value matches, set pass to true
 					break; // Break early since at least one condition is satisfied
 				}
@@ -505,7 +505,7 @@ function whiteAndBlackLister(jobConfig, params) {
 				if (!Array.isArray(propVals)) propVals = [propVals];
 				let foundMatch = false;
 				for (const val of propVals) {
-					if (record?.properties?.[key] === val) foundMatch = true;
+					if (record?.properties?.[key]?.toString() === val?.toString()) foundMatch = true;
 				}
 				if (foundMatch) {
 					pass = false;

--- a/components/transforms.js
+++ b/components/transforms.js
@@ -79,7 +79,7 @@ function ezTransforms(jobConfig) {
 						delete record.properties[key];
 					}
 				}
-		
+
 
 
 			}
@@ -405,10 +405,13 @@ function whiteAndBlackLister(jobConfig, params) {
 		propKeyWhitelist = [],
 		propKeyBlacklist = [],
 		propValBlacklist = [],
-		propValWhitelist = []
+		propValWhitelist = [],
+		comboWhiteList = {},
+		comboBlackList = {}
 	} = params;
 
 	return function whiteAndBlackList(record) {
+		let pass;
 		//check for event whitelist
 		if (eventWhitelist.length) {
 			if (!eventWhitelist.includes(record?.event)) {
@@ -427,7 +430,7 @@ function whiteAndBlackLister(jobConfig, params) {
 
 		//check for prop key whitelist
 		if (propKeyWhitelist.length) {
-			let pass = false;
+			pass = false;
 			for (const key in record?.properties) {
 				if (propKeyWhitelist.includes(key)) {
 					pass = true;
@@ -441,7 +444,7 @@ function whiteAndBlackLister(jobConfig, params) {
 
 		//check for prop key blacklist
 		if (propKeyBlacklist.length) {
-			let pass = true;
+			pass = true;
 			for (const key in record?.properties) {
 				if (propKeyBlacklist.includes(key)) {
 					jobConfig.blackListSkipped++;
@@ -453,7 +456,7 @@ function whiteAndBlackLister(jobConfig, params) {
 
 		//check for prop val whitelist
 		if (propValWhitelist.length) {
-			let pass = false;
+			pass = false;
 			for (const key in record?.properties) {
 				if (propValWhitelist.includes(record.properties[key])) {
 
@@ -468,7 +471,7 @@ function whiteAndBlackLister(jobConfig, params) {
 
 		//check for prop val blacklist
 		if (propValBlacklist.length) {
-			let pass = true;
+			pass = true;
 			for (const key in record?.properties) {
 				if (propValBlacklist.includes(record.properties[key])) {
 					jobConfig.blackListSkipped++;
@@ -476,6 +479,39 @@ function whiteAndBlackLister(jobConfig, params) {
 				}
 			}
 			if (!pass) return {};
+		}
+
+		//check for combo whitelist
+		if (Object.keys(comboWhiteList).length) {
+			pass = false;
+			for (const key in comboBlackList) {
+				let propVals = comboBlackList[key];
+				if (!Array.isArray(propVals)) propVals = [propVals];
+				for (const val of propVals) {
+					if (record?.properties?.[key] === val) pass = true;
+				}
+			}
+			if (!pass) {
+				jobConfig.whiteListSkipped++;
+				return {};
+			}
+		}
+
+
+		//check for combo blacklist
+		if (Object.keys(comboBlackList).length) {
+			pass = true;
+			for (const key in comboBlackList) {
+				let propVals = comboBlackList[key];
+				if (!Array.isArray(propVals)) propVals = [propVals];
+				for (const val of propVals) {
+					if (record?.properties?.[key] === val) pass = false;
+				}
+			}
+			if (!pass) {
+				jobConfig.blackListSkipped++;
+				return {};
+			}
 		}
 
 		return record;

--- a/index.d.ts
+++ b/index.d.ts
@@ -20,9 +20,7 @@ declare namespace main {
     opts: Options,
     finish?: Function
   ): import("stream").Transform;
-  async function validateToken(
-    token: string
-  ): Promise<{
+  async function validateToken(token: string): Promise<{
     token: string;
     valid: boolean;
     type: "idmgmt_v2" | "idmgmt_v3" | "unknown";
@@ -108,6 +106,8 @@ declare namespace main {
     propKeyBlacklist: string[];
     propValWhitelist: string[];
     propValBlacklist: string[];
+    comboWhiteList: { [key: string]: string[] };
+    comboBlackList: { [key: string]: string[] };
   };
 
   type Regions = "US" | "EU";
@@ -159,11 +159,11 @@ declare namespace main {
      * - default `true`
      */
     verbose?: boolean;
-	/**
-	 * - show the progress bar; only matters if verbose is unset
-	 * - default `false`
-	 */
-	showProgress?: boolean
+    /**
+     * - show the progress bar; only matters if verbose is unset
+     * - default `false`
+     */
+    showProgress?: boolean;
     /**
      * - apply various transformations to ensure data is properly ingested
      * - default `true`
@@ -288,6 +288,14 @@ declare namespace main {
      * don't import events with property values on the blacklist
      */
     propValBlacklist?: string[];
+	/**
+	 * only import events which have property keys and values on the whilelist
+	 */
+	comboWhiteList?: {[key: string]: string[]};
+	/**
+	 * don't import events which have property keys and values on the blacklist
+	 */
+	comboBlackList?: {[key: string]: string[]};
     /**
      * the start date of the export (events only)
      */

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "mixpanel-import",
-  "version": "2.4.05",
+  "version": "2.5.45",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "mixpanel-import",
-      "version": "2.4.05",
+      "version": "2.5.45",
       "license": "ISC",
       "dependencies": {
         "ak-tools": "^1.0.43",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,15 +1,15 @@
 {
   "name": "mixpanel-import",
-  "version": "2.5.45",
+  "version": "2.5.554",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "mixpanel-import",
-      "version": "2.5.45",
+      "version": "2.5.554",
       "license": "ISC",
       "dependencies": {
-        "ak-tools": "^1.0.43",
+        "ak-tools": "^1.0.63",
         "chance": "^1.1.7",
         "dayjs": "^1.11.7",
         "dotenv": "^10.0.0",
@@ -1402,9 +1402,9 @@
       }
     },
     "node_modules/ak-tools": {
-      "version": "1.0.43",
-      "resolved": "https://registry.npmjs.org/ak-tools/-/ak-tools-1.0.43.tgz",
-      "integrity": "sha512-RJfn55bCEdgAOsZCuOPBVJa3qK5P4Sk07981Oyd3vltAh4LyeViK54XuNkzHucApFEWjwhdrFQaaw5kx3xRU9Q=="
+      "version": "1.0.63",
+      "resolved": "https://registry.npmjs.org/ak-tools/-/ak-tools-1.0.63.tgz",
+      "integrity": "sha512-yJxe2cA1ZTLtIuHDxoBbZIOvbjmueGqZRPjugH75673Z+wABHvC2d0HX04K8A1khNLiE37lqifJvc6KzNzvDgQ=="
     },
     "node_modules/ansi-escapes": {
       "version": "4.3.2",
@@ -6081,9 +6081,9 @@
       }
     },
     "ak-tools": {
-      "version": "1.0.43",
-      "resolved": "https://registry.npmjs.org/ak-tools/-/ak-tools-1.0.43.tgz",
-      "integrity": "sha512-RJfn55bCEdgAOsZCuOPBVJa3qK5P4Sk07981Oyd3vltAh4LyeViK54XuNkzHucApFEWjwhdrFQaaw5kx3xRU9Q=="
+      "version": "1.0.63",
+      "resolved": "https://registry.npmjs.org/ak-tools/-/ak-tools-1.0.63.tgz",
+      "integrity": "sha512-yJxe2cA1ZTLtIuHDxoBbZIOvbjmueGqZRPjugH75673Z+wABHvC2d0HX04K8A1khNLiE37lqifJvc6KzNzvDgQ=="
     },
     "ansi-escapes": {
       "version": "4.3.2",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "mixpanel-import",
-  "version": "2.5.553",
+  "version": "2.5.554",
   "description": "stream and import data to mixpanel from node.js",
   "main": "index.js",
   "types": "index.d.ts",

--- a/package.json
+++ b/package.json
@@ -38,7 +38,7 @@
   },
   "homepage": "https://github.com/ak--47/mixpanel-import#readme",
   "dependencies": {
-    "ak-tools": "^1.0.43",
+    "ak-tools": "^1.0.63",
     "chance": "^1.1.7",
     "dayjs": "^1.11.7",
     "dotenv": "^10.0.0",

--- a/tests/e2e.test.js
+++ b/tests/e2e.test.js
@@ -208,7 +208,7 @@ describe("in memory", () => {
 	test(
 		"users",
 		async () => {
-			const data = await mp({ token: MP_TOKEN }, moarPpl, { ...opts, recordType: "user", fixData: true});
+			const data = await mp({ token: MP_TOKEN }, moarPpl, { ...opts, recordType: "user", fixData: true });
 			expect(data.success).toBe(10000);
 			expect(data.failed).toBe(0);
 			expect(data.duration).toBeGreaterThan(0);
@@ -1141,6 +1141,30 @@ describe("white + blacklist", () => {
 			expect(job.blackListSkipped).toBe(1);
 		},
 		longTimeout
+	);
+
+	test(
+		"combo blacklist",
+		async () => {
+			const job = await mp({}, data, { ...opts, recordType: "event", comboBlackList: { happy: "nope" } });
+			expect(job.success).toBe(4);
+			expect(job.failed).toBe(0);
+			expect(job.total).toBe(5);
+			expect(job.empty).toBe(1);
+			expect(job.blackListSkipped).toBe(1);
+		}, longTimeout
+	);
+
+	test(
+		"combo whiteList",
+		async () => {
+			const job = await mp({}, data, { ...opts, recordType: "event", comboWhiteList: { happy: "nope" } });
+			expect(job.success).toBe(1);
+			expect(job.failed).toBe(0);
+			expect(job.total).toBe(5);
+			expect(job.empty).toBe(4);
+			expect(job.whiteListSkipped).toBe(4);
+		}, longTimeout
 	);
 
 	test("dry runs", async () => {

--- a/tests/unit.test.js
+++ b/tests/unit.test.js
@@ -468,6 +468,90 @@ describe("transforms", () => {
 	});
 
 
+	// Sample job config for testing
+
+	// comboWhitelist tests
+	test("combo: whitelist", () => {
+		const sampleJobConfig = {
+			whiteListSkipped: 0,
+			blackListSkipped: 0,
+		};
+
+		const params = {
+			comboWhiteList: {
+				key1: ["allowedValue1", "allowedValue2"],
+				key2: "allowedValue3"
+			}
+		};
+		const recordAllowed1 = { properties: { key1: "allowedValue1", key2: "allowedValue3" } };
+		const recordAllowed2 = { properties: { key1: "allowedValue2", key2: "allowedValue3" } };
+		const recordDisallowed = { properties: { key1: "disallowedValue", key2: "allowedValue3" } };
+
+		expect(whiteAndBlackLister(sampleJobConfig, params)(recordAllowed1)).toEqual(recordAllowed1);
+		expect(whiteAndBlackLister(sampleJobConfig, params)(recordAllowed2)).toEqual(recordAllowed2);
+		expect(whiteAndBlackLister(sampleJobConfig, params)(recordDisallowed)).toEqual({});
+	});
+
+	// comboBlacklist tests
+	test("combo: blacklist", () => {
+		const sampleJobConfig = {
+			whiteListSkipped: 0,
+			blackListSkipped: 0,
+		};
+
+		const params = {
+			comboBlackList: {
+				key1: ["disallowedValue1", "disallowedValue2"],
+				key2: "disallowedValue3"
+			}
+		};
+		const recordAllowed = { event: "foo", properties: { key1: "allowedValue", key2: "allowedValue" } };
+		const recordDisallowed1 = { event: "bar", properties: { key1: "disallowedValue1", key2: "allowedValue" } };
+		const recordDisallowed2 = { event: "baz", properties: { key1: "allowedValue", key2: "disallowedValue3" } };
+
+		expect(whiteAndBlackLister(sampleJobConfig, params)(recordAllowed)).toEqual(recordAllowed);
+		expect(whiteAndBlackLister(sampleJobConfig, params)(recordDisallowed1)).toEqual({});
+		expect(whiteAndBlackLister(sampleJobConfig, params)(recordDisallowed2)).toEqual({});
+	});
+
+	test("combo: whitelist", () => {
+		const params = {
+			comboWhiteList: {
+				key1: "value1",
+				key2: ["value2", "value3"] // Test with multiple values
+			}
+		};
+
+		const recordAllowed1 = { properties: { key1: "value1" } };
+		const recordAllowed2 = { properties: { key2: "value2" } };
+		const recordAllowed3 = { properties: { key2: "value3" } }; // Test with multiple values
+		const recordDisallowed = { properties: { key1: "wrongValue" } };
+
+		expect(whiteAndBlackLister(sampleJobConfig, params)(recordAllowed1)).toEqual(recordAllowed1);
+		expect(whiteAndBlackLister(sampleJobConfig, params)(recordAllowed2)).toEqual(recordAllowed2);
+		expect(whiteAndBlackLister(sampleJobConfig, params)(recordAllowed3)).toEqual(recordAllowed3);
+		expect(whiteAndBlackLister(sampleJobConfig, params)(recordDisallowed)).toEqual({});
+	});
+
+	test("combo: blacklist", () => {
+		const params = {
+			comboBlackList: {
+				key1: "value1",
+				key2: ["value2", "value3"] // Test with multiple values
+			}
+		};
+
+		const recordAllowed = { properties: { key1: "wrongValue" } };
+		const recordDisallowed1 = { properties: { key1: "value1" } };
+		const recordDisallowed2 = { properties: { key2: "value2" } };
+		const recordDisallowed3 = { properties: { key2: "value3" } }; // Test with multiple values
+
+		expect(whiteAndBlackLister(sampleJobConfig, params)(recordAllowed)).toEqual(recordAllowed);
+		expect(whiteAndBlackLister(sampleJobConfig, params)(recordDisallowed1)).toEqual({});
+		expect(whiteAndBlackLister(sampleJobConfig, params)(recordDisallowed2)).toEqual({});
+		expect(whiteAndBlackLister(sampleJobConfig, params)(recordDisallowed3)).toEqual({});
+	});
+
 	test("flatten: nested objects", () => {
 		const record = {
 			event: "foo",

--- a/tests/unit.test.js
+++ b/tests/unit.test.js
@@ -511,7 +511,7 @@ describe("transforms", () => {
 		expect(sampleJobConfig.whiteListSkipped).toBe(1);
 	});
 
-	test("combo: whitelist with non-matching types", () => {
+	test("combo: whitelist stringify all", () => {
 		params = {
 			comboWhiteList: {
 				count: [10] // Expecting a number
@@ -519,7 +519,7 @@ describe("transforms", () => {
 		};
 		const recordString = { properties: { count: '10' } }; // String type instead of number
 		const recordNumber = { properties: { count: 10 } }; // Correct type
-		expect(whiteAndBlackLister(sampleJobConfig, params)(recordString)).toEqual({});
+		expect(whiteAndBlackLister(sampleJobConfig, params)(recordString)).toEqual(recordString);
 		expect(whiteAndBlackLister(sampleJobConfig, params)(recordNumber)).toEqual(recordNumber);
 	});
 

--- a/tests/unit.test.js
+++ b/tests/unit.test.js
@@ -523,17 +523,16 @@ describe("transforms", () => {
 		expect(whiteAndBlackLister(sampleJobConfig, params)(recordNumber)).toEqual(recordNumber);
 	});
 
-	test("combo: blacklist with mixed types and nested properties", () => {
+	test("combo: blacklist nested props are OK", () => {
 		params = {
 			comboBlackList: {
-				'details.size': ['large'], // Nested property
 				age: [30] // Number type
 			}
 		};
-		const recordNestedAllowed = { properties: { details: { size: 'small' }, age: 30 } }; // Mixed pass and fail conditions
-		const recordNestedDisallowed = { properties: { details: { size: 'large' }, age: 29 } }; // Should not pass (size matches)
-		expect(whiteAndBlackLister(sampleJobConfig, params)(recordNestedAllowed)).toEqual(recordNestedAllowed);
-		expect(whiteAndBlackLister(sampleJobConfig, params)(recordNestedDisallowed)).toEqual({});
+		const recordNotAllowed = { properties: { details: { size: 'small' }, age: 30 } }; // Mixed pass and fail conditions
+		const recordAllowed = { properties: { details: { size: 'large' }, age: 29 } }; // Should not pass (size matches)
+		expect(whiteAndBlackLister(sampleJobConfig, params)(recordNotAllowed)).toEqual({});
+		expect(whiteAndBlackLister(sampleJobConfig, params)(recordAllowed)).toEqual(recordAllowed);
 	});
 
 	test("combo: whitelist and blacklist empty", () => {
@@ -545,7 +544,7 @@ describe("transforms", () => {
 		expect(whiteAndBlackLister(sampleJobConfig, params)(recordAny)).toEqual(recordAny);
 	});
 
-	test("combo: blacklist with all properties matching", () => {
+	test("combo: blacklist with some properties matching", () => {
 		params = {
 			comboBlackList: {
 				key1: ['value1'],
@@ -555,7 +554,7 @@ describe("transforms", () => {
 		const recordAllMatch = { properties: { key1: 'value1', key2: 'value2' } };
 		const recordPartialMatch = { properties: { key1: 'value1', key2: 'otherValue' } };
 		expect(whiteAndBlackLister(sampleJobConfig, params)(recordAllMatch)).toEqual({});
-		expect(whiteAndBlackLister(sampleJobConfig, params)(recordPartialMatch)).toEqual(recordPartialMatch);
+		expect(whiteAndBlackLister(sampleJobConfig, params)(recordPartialMatch)).toEqual({});
 	});
 
 	test("flatten: nested objects", () => {


### PR DESCRIPTION
you can now do blacklisting or while list by passing options `comboWhiteList` and `comboBlackList` whose shape are `{[key:string]: string[]}` .... so `{ comboWhiteList: { hello: ['earth', 'mars'] }` would _only_ allow events where who had a `hello` property with values `earth` or `mars` (the same blacklist _would not_ allow events which matched in the same way.

this makes it easy to do stuff like:

```
{
  comboBlackList: {  "API Environment": ["dev", "stg", "local", "yocal"]
}
```

etc...